### PR TITLE
feat: add json schema against data validation mixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@sweetalert2/theme-bootstrap-4": "5.0.15",
     "@websanova/vue-upload": "^2.1.9",
+    "ajv": "^8.12.0",
     "axios": "1.3.2",
     "bootstrap": "4.6.2",
     "bootstrap-vue": "2.23.1",

--- a/src/mixins/validations.js
+++ b/src/mixins/validations.js
@@ -1,0 +1,11 @@
+import Ajv from 'ajv';
+
+export const validateMixin = {
+  methods: {
+    validateJsonDataAgainstSchema(data, schema) {
+      const ajv = new Ajv();
+      const validate = ajv.compile(schema);
+      return { success: validate(data), error: ajv.errorsText(validate.errors) }
+    },
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1777,7 +1777,7 @@ ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
+ajv@^8.0.1, ajv@^8.12.0:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==


### PR DESCRIPTION
Uses the Ajv JSON schema validator:
https://github.com/ajv-validator/ajv
https://ajv.js.org/

Clickup Task:
https://app.clickup.com/t/862j2jggt

README and test on the ajv validator:
https://github.com/ntls-io/json-schema-validator